### PR TITLE
Add Chinese (Traditional) to opensubtitles converter

### DIFF
--- a/babelfish/converters/opensubtitles.py
+++ b/babelfish/converters/opensubtitles.py
@@ -14,9 +14,9 @@ class OpenSubtitlesConverter(LanguageReverseConverter):
     def __init__(self):
         self.alpha3b_converter = language_converters['alpha3b']
         self.alpha2_converter = language_converters['alpha2']
-        self.to_opensubtitles = {('por', 'BR'): 'pob', ('gre', None): 'ell', ('srp', None): 'scc', ('srp', 'ME'): 'mne'}
+        self.to_opensubtitles = {('por', 'BR'): 'pob', ('gre', None): 'ell', ('srp', None): 'scc', ('srp', 'ME'): 'mne', ('chi', 'TW'): 'zht'}
         self.from_opensubtitles = CaseInsensitiveDict({'pob': ('por', 'BR'), 'pb': ('por', 'BR'), 'ell': ('ell', None),
-                                                       'scc': ('srp', None), 'mne': ('srp', 'ME')})
+                                                       'scc': ('srp', None), 'mne': ('srp', 'ME'), 'zht': ('zho', 'TW')})
         self.codes = (self.alpha2_converter.codes | self.alpha3b_converter.codes | set(self.from_opensubtitles.keys()))
 
     def convert(self, alpha3, country=None, script=None):

--- a/babelfish/tests.py
+++ b/babelfish/tests.py
@@ -203,8 +203,10 @@ class TestLanguage(TestCase, _Py26FixTestCase):
     def test_converter_opensubtitles(self):
         self.assertEqual(Language('fra').opensubtitles, Language('fra').alpha3b)
         self.assertEqual(Language('por', 'BR').opensubtitles, 'pob')
+        self.assertEqual(Language('zho', 'TW').opensubtitles, 'zht')
         self.assertEqual(Language.fromopensubtitles('fre'), Language('fra'))
         self.assertEqual(Language.fromopensubtitles('pob'), Language('por', 'BR'))
+        self.assertEqual(Language.fromopensubtitles('zht'), Language('zho', 'TW'))
         self.assertEqual(Language.fromopensubtitles('pb'), Language('por', 'BR'))
         # Montenegrin is not recognized as an ISO language (yet?) but for now it is
         # unofficially accepted as Serbian from Montenegro
@@ -212,7 +214,7 @@ class TestLanguage(TestCase, _Py26FixTestCase):
         self.assertEqual(Language.fromcode('pob', 'opensubtitles'), Language('por', 'BR'))
         self.assertRaises(LanguageReverseError, lambda: Language.fromopensubtitles('zzz'))
         self.assertRaises(LanguageConvertError, lambda: Language('aaa').opensubtitles)
-        self.assertEqual(len(language_converters['opensubtitles'].codes), 607)
+        self.assertEqual(len(language_converters['opensubtitles'].codes), 608)
 
         # test with all the LANGUAGES from the opensubtitles api
         # downloaded from: http://www.opensubtitles.org/addons/export_languages.php


### PR DESCRIPTION
Chinese (Traditional) is supported by opensubtitles.org, but there is no way to distinguish Chinese (Simplified) and Chinese (Traditional) by using only ISO-639-2/b `chi`. So I extended the converter to convert `zht` which is used by opensubtitles.org: http://www.opensubtitles.org/addons/export_languages.php