### PR TITLE
build: remove redundant and wrong include=

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
     "Topic :: Software Development :: Internationalization",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-include = ["data/"]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
The include= key specifies paths relative to the top source directory,
not "babelfish" package.  However, it is unnecessary since poetry
automatically includes all data from packages.