### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/babelfish/compat.py
+++ b/babelfish/compat.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2013 the BabelFish authors. All rights reserved.
+# Use of this source code is governed by the 3-clause BSD license
+# that can be found in the LICENSE file.
+#
+from sys import version_info as _python
+
+if _python >= (3, 9):
+    # introduced in python 3.9
+    from importlib.resources import files
+else:
+    from importlib_resources import files
+
+
+if _python >= (3, 10):
+    # .select() was introduced in 3.10
+    from importlib.metadata import entry_points, EntryPoint as _EntryPoint
+else:
+    from importlib_metadata import entry_points, EntryPoint as _EntryPoint
+
+
+def resource_stream(pkg, path):
+    return files(pkg).joinpath(f'{path}').open('rb')
+
+
+def iter_entry_points(group, **kwargs):
+    return entry_points().select(group=group, **kwargs)
+
+
+class EntryPoint(_EntryPoint):
+    @staticmethod
+    def parse(eps):
+        return EntryPoint(*map(str.strip, eps.split('=')), None)
+
+    def resolve(self):
+        return self.load()

--- a/babelfish/converters/__init__.py
+++ b/babelfish/converters/__init__.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the 3-clause BSD license
 # that can be found in the LICENSE file.
 #
-from pkg_resources import iter_entry_points, EntryPoint
+from ..compat import iter_entry_points, EntryPoint
 from ..exceptions import LanguageConvertError, LanguageReverseError
 
 try:

--- a/babelfish/country.py
+++ b/babelfish/country.py
@@ -7,9 +7,9 @@
 from __future__ import unicode_literals
 from collections import namedtuple
 from functools import partial
-from pkg_resources import resource_stream  # @UnresolvedImport
 from .converters import ConverterManager
 from . import basestr
+from .compat import resource_stream
 
 
 COUNTRIES = {}

--- a/babelfish/language.py
+++ b/babelfish/language.py
@@ -7,12 +7,12 @@
 from __future__ import unicode_literals
 from collections import namedtuple
 from functools import partial
-from pkg_resources import resource_stream  # @UnresolvedImport
 from .converters import ConverterManager
 from .country import Country
 from .exceptions import LanguageConvertError
 from .script import Script
 from . import basestr
+from .compat import resource_stream
 
 
 LANGUAGES = set()

--- a/babelfish/script.py
+++ b/babelfish/script.py
@@ -6,8 +6,8 @@
 #
 from __future__ import unicode_literals
 from collections import namedtuple
-from pkg_resources import resource_stream  # @UnresolvedImport
 from . import basestr
+from .compat import resource_stream
 
 #: Script code to script name mapping
 SCRIPTS = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+importlib-resources = {version = "^5.0", python = "<3.9"}
+importlib-metadata = {version = "^4.6", python = "<3.10"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,7 +1,7 @@
 from babelfish.converters import LanguageReverseConverter
 import pytest
-from pkg_resources import resource_stream
 from babelfish import language_converters
+from babelfish.compat import resource_stream
 from babelfish.exceptions import LanguageConvertError, LanguageReverseError
 from babelfish.language import Language
 


### PR DESCRIPTION
pkg_resources is deprecated in favor of importlib.{resources,metadata}

Closes Diaoul#46
See-also: https://setuptools.pypa.io/en/latest/pkg_resources.html
See-also: https://docs.python.org/3/library/importlib.resources.html
See-also: https://docs.python.org/3/library/importlib.metadata.html
Signed-off-by: Mubashshir <ahmubashshir@gmail.com>
